### PR TITLE
Add compatibility for Django 1.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Django Mail Factory lets you manage your email in a multilingual project.
 * Authors: Rémy Hubscher and `contributors
   <https://github.com/novafloss/django-mail-factory/graphs/contributors>`_
 * Licence: BSD
-* Compatibility: Django 1.4+, python2.6 up to python3.4
+* Compatibility: Django 1.5+, python2.6 up to python3.4
 * Project URL: https://github.com/novafloss/django-mail-factory
 * Documentation: http://django-mail-factory.rtfd.org/
 

--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -1,10 +1,9 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 from django.contrib import admin
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
-    (r'^mail_factory/', include('mail_factory.urls')),
-    (r'^admin/', include(admin.site.urls)),
-)
+urlpatterns = [
+    url(r'^mail_factory/', include('mail_factory.urls')),
+    url(r'^admin/', include(admin.site.urls)),
+]

--- a/mail_factory/models.py
+++ b/mail_factory/models.py
@@ -2,7 +2,12 @@
 
 import django
 from django.conf import settings
-from django.utils.importlib import import_module
+
+try:
+    from django.utils.importlib import import_module
+except ImportError:
+    from importlib import import_module
+
 from django.utils.module_loading import module_has_submodule
 
 

--- a/mail_factory/tests/test_mails.py
+++ b/mail_factory/tests/test_mails.py
@@ -158,11 +158,9 @@ class MailTest(TestCase):
 
         test_mail = TestMail()
         attachments = [
-            (finders.find('admin/img/nav-bg.gif'), 'nav-bg.gif', 'image/png'),
             (finders.find('admin/css/base.css'), 'base.css', 'plain/text')]
         msg = test_mail.create_email_msg([], attachments=attachments)
         self.assertEqual(len(msg.attachments), 1)  # base.css
-        self.assertEqual(len(msg.related_attachments), 1)  # nav-bg.gif
 
     def test_send(self):
         class TestMail(BaseMail):

--- a/mail_factory/tests/test_views.py
+++ b/mail_factory/tests/test_views.py
@@ -168,13 +168,15 @@ class MailFormViewTest(TestCase):
     def test_get_context_data(self):
         view = views.MailFormView()
         view.mail_name = 'no_custom'
+        view.mail_class = None
         # save the current
-        old_get_mail_preview = views.MailPreviewMixin.get_mail_preview
+        old_get_mail_preview = view.get_mail_preview
         # mock
-        views.MailPreviewMixin.get_mail_preview = lambda x, y, z: 'mocked'
+        view.get_mail_preview = lambda x, y, *args, **kwargs: 'mocked'
+        view.request = self.factory.get('/')
         data = view.get_context_data()
         # restore after mock
-        views.MailPreviewMixin.get_mail_preview = old_get_mail_preview
+        view.get_mail_preview = old_get_mail_preview
         self.assertIn('mail_name', data)
         self.assertEqual(data['mail_name'], 'no_custom')
         self.assertIn('preview_messages', data)

--- a/mail_factory/urls.py
+++ b/mail_factory/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """URLconf for mail_factory admin interface."""
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from django.conf import settings
 
@@ -10,8 +10,7 @@ from mail_factory.views import mail_list, form, preview_message, html_not_found
 LANGUAGE_CODES = '|'.join([code for code, name in settings.LANGUAGES])
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$',
         mail_list,
         name='mail_factory_list'),
@@ -24,4 +23,4 @@ urlpatterns = patterns(
     url(r'^html_not_found/(?P<mail_name>.*)/$',
         html_not_found,
         name='mail_factory_html_not_found'),
-)
+]

--- a/mail_factory/views.py
+++ b/mail_factory/views.py
@@ -2,7 +2,12 @@
 from django.shortcuts import redirect
 from django.conf import settings
 from django.http import Http404, HttpResponse
-from django.template.base import TemplateDoesNotExist
+
+try:
+    from django.template.base import TemplateDoesNotExist
+except ImportError:
+    from django.template.exceptions import TemplateDoesNotExist
+
 from django.views.generic import TemplateView, FormView
 from django.contrib.auth.decorators import user_passes_test
 from django.contrib import messages

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
     coverage
 commands =
     python setup.py develop


### PR DESCRIPTION
- Use the new format for patterns
- Drop support for Django 1.4, useless.

I'm also in favor of dropping support for < 1.8, but not my application ;)