### PR TITLE
Use standard library instead of django.utils.importlib

### DIFF
--- a/mail_factory/__init__.py
+++ b/mail_factory/__init__.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 """Django Mail Manager"""
 
+from mail_factory.factory import MailFactory
+from mail_factory.forms import MailForm  # NOQA
+from mail_factory.mails import BaseMail  # NOQA
+
 pkg_resources = __import__('pkg_resources')
 distribution = pkg_resources.get_distribution('django-mail-factory')
 
 #: Module version, as defined in PEP-0396.
 __version__ = distribution.version
 
-from mail_factory.factory import MailFactory
-from mail_factory.forms import MailForm  # NOQA
-from mail_factory.mails import BaseMail  # NOQA
 
 factory = MailFactory()
 

--- a/mail_factory/models.py
+++ b/mail_factory/models.py
@@ -2,8 +2,13 @@
 
 import django
 from django.conf import settings
-from django.utils.importlib import import_module
 from django.utils.module_loading import module_has_submodule
+
+try:
+    from importlib import import_module
+except ImportError:
+    # Compatibility for python-2.6
+    from django.utils.importlib import import_module
 
 
 def autodiscover():


### PR DESCRIPTION
> django.utils.importlib is a compatibility library for when Python 2.6 was
> still supported. It has been obsolete since Django 1.7, which dropped support
> for Python 2.6, and is removed in 1.9 per the deprecation cycle.
> Use Python's import_module function instead
> — [1]

References:
[1] http://stackoverflow.com/a/32763639
[2] https://docs.djangoproject.com/en/1.9/internals/deprecation/#deprecation-removed-in-1-9