### PR TITLE
Refs #71 #69 Fix django 1.10 compatibility with render and Context

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ Changelog
 0.18 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix django 1.10 compatibility (render() must be called with a dict, not a Context)
 
 
 0.17 (2017-05-10)

--- a/mail_factory/mails.py
+++ b/mail_factory/mails.py
@@ -4,7 +4,7 @@ from os.path import join
 import html2text
 
 from django.conf import settings
-from django.template import Context, TemplateDoesNotExist
+from django.template import TemplateDoesNotExist
 from django.template.loader import select_template
 from django.utils import translation
 
@@ -29,8 +29,7 @@ class BaseMail(object):
         """Create a mail instance from a context."""
         # Create the context
         context = context or {}
-        c = self.get_context_data(**context)
-        self.context = Context(c)
+        self.context = self.get_context_data(**context)
         self.lang = self.get_language()
 
         # Check that all the mandatory context is present.


### PR DESCRIPTION
Fix th deprecation warning:
/site-packages/mail_factory/mails.py:96: RemovedInDjango110Warning: render() must be called with a dict, not a Context.
