### PR TITLE
Do not load url templatetag in templates

### DIFF
--- a/mail_factory/templates/mail_factory/base.html
+++ b/mail_factory/templates/mail_factory/base.html
@@ -1,7 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load admin_urls %}
 {% load i18n admin_static admin_list %}
-{% load url from future %}
 
 {% block extrastyle %}
     {{ block.super }}

--- a/mail_factory/templates/mail_factory/form.html
+++ b/mail_factory/templates/mail_factory/form.html
@@ -1,5 +1,4 @@
 {% extends "mail_factory/base.html" %}
-{% load url from future %}
 {% load i18n %}
 
 {% if not is_popup %}

--- a/mail_factory/templates/mail_factory/html_not_found.html
+++ b/mail_factory/templates/mail_factory/html_not_found.html
@@ -1,5 +1,4 @@
 {% extends "mail_factory/base.html" %}
-{% load url from future %}
 {% load i18n %}
 
 {% block content %}

--- a/mail_factory/templates/mail_factory/list.html
+++ b/mail_factory/templates/mail_factory/list.html
@@ -1,5 +1,4 @@
 {% extends "mail_factory/base.html" %}
-{% load url from future %}
 
 {% block content %}
     <div id="content-main">


### PR DESCRIPTION
We had this warning:

> RemovedInDjango19Warning: Loading the `url` tag from the `future`
> library is deprecated and will be removed in Django 1.9. Use the
> default `url` tag instead.