### PR TITLE
Migrate GitHub organization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ Changelog
 0.21 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Migrate GitHub organization
 
 
 0.20 (2017-10-12)

--- a/INSTALL
+++ b/INSTALL
@@ -2,4 +2,4 @@
 Installation
 ############
 
-See https://github.com/novafloss/django-mail-factory/ for details about the installation.
+See https://github.com/peopledoc/django-mail-factory/ for details about the installation.

--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@
 Django Mail Factory
 ###################
 
-.. image:: https://secure.travis-ci.org/novafloss/django-mail-factory.png?branch=master
+.. image:: https://secure.travis-ci.org/peopledoc/django-mail-factory.png?branch=master
    :alt: Build Status
-   :target: https://travis-ci.org/novafloss/django-mail-factory
+   :target: https://travis-ci.org/peopledoc/django-mail-factory
 .. image:: https://pypip.in/v/django-mail-factory/badge.png
    :target: https://crate.io/packages/django-mail-factory/
 .. image:: https://pypip.in/d/django-mail-factory/badge.png
@@ -13,10 +13,10 @@ Django Mail Factory
 Django Mail Factory lets you manage your email in a multilingual project.
 
 * Authors: Rémy Hubscher and `contributors
-  <https://github.com/novafloss/django-mail-factory/graphs/contributors>`_
+  <https://github.com/peopledoc/django-mail-factory/graphs/contributors>`_
 * Licence: BSD
 * Compatibility: Django 1.8, 1.9, 1.10, 1.11, python2.7, python3.4 and python3.5
-* Project URL: https://github.com/novafloss/django-mail-factory
+* Project URL: https://github.com/peopledoc/django-mail-factory
 * Documentation: http://django-mail-factory.rtfd.org/
 
 
@@ -27,7 +27,7 @@ Setup your environment:
 
 ::
 
-    git clone https://github.com/novafloss/django-mail-factory.git
+    git clone https://github.com/peopledoc/django-mail-factory.git
     cd django-mail-factory
 
 Hack and run the tests using `Tox <https://pypi.python.org/pypi/tox>`_ to test

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ Django Mail Factory has support for:
 Other resources
 ---------------
 
-Fork it on: http://github.com/novafloss/django-mail-factory/
+Fork it on: http://github.com/peopledoc/django-mail-factory/
 
 Documentation: http://django-mail-factory.rtfd.org/
 
@@ -38,7 +38,7 @@ From PyPI::
 
 From the github tree::
 
-    pip install -e http://github.com/novafloss/django-mail-factory/
+    pip install -e http://github.com/peopledoc/django-mail-factory/
 
 Then add ``mail_factory`` to your *INSTALLED_APPS*::
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
         keywords='django mail manager',
         author='Rémy Hubscher',
         author_email='hubscher.remy@gmail.com',
-        url='https://github.com/novafloss/django-mail-factory',
+        url='https://github.com/peopledoc/django-mail-factory',
         license='BSD Licence',
         packages=find_packages(),
         include_package_data=True,


### PR DESCRIPTION
At PeopleDoc, we've decided to migrate all projects from novafloss
organization to the main PeopleDoc one.